### PR TITLE
Clone target branch in new merge request screen to top of the page

### DIFF
--- a/scripts/gitlab.js
+++ b/scripts/gitlab.js
@@ -504,6 +504,9 @@ function prettifyCreatePullRequestPage() {
             titleElement.value = `${titleRegexMatch[1]} ${titleRegexMatch[2]}`;
         }
     }
+
+    let $titleRow = $('#merge_request_title').closest('.form-group.row');
+    $('#merge_request_target_branch').closest('.form-group.row').clone().insertBefore($titleRow);
 }
 
 function addBadges() {
@@ -658,3 +661,4 @@ setTimeout(function() {
         addBadges();
     }
 }, 0);
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7727916/55882497-eff3b080-5ba4-11e9-9b83-b84438245079.png)
It will no longer drive people insane when they fill out title, description, approvers and what not, only to realize afterwards they need to change target branch, which throws away all that work.